### PR TITLE
feat(ui): render reminder and cron messages as styled components

### DIFF
--- a/web/static/chat.js
+++ b/web/static/chat.js
@@ -191,7 +191,12 @@ window.ChatClient ||= class ChatClient {
                 this.wsContainer.send({ content: msg });
             }, !!id);
         } else {
-            msgEl.textContent = content;
+            var scheduled = MessageRenderer.parseScheduledMessage(content);
+            if (scheduled) {
+                msgEl.appendChild(MessageRenderer.renderScheduledMessage(scheduled));
+            } else {
+                msgEl.textContent = content;
+            }
         }
 
         if (id) {
@@ -217,7 +222,12 @@ window.ChatClient ||= class ChatClient {
                 this.wsContainer.send({ content: msg });
             }, true);
         } else {
-            msgEl.textContent = content;
+            var scheduled = MessageRenderer.parseScheduledMessage(content);
+            if (scheduled) {
+                msgEl.appendChild(MessageRenderer.renderScheduledMessage(scheduled));
+            } else {
+                msgEl.textContent = content;
+            }
         }
 
         if (id) {

--- a/web/static/message-renderer.js
+++ b/web/static/message-renderer.js
@@ -74,6 +74,37 @@ window.MessageRenderer = {
         });
     },
 
+    parseScheduledMessage(content) {
+        if (!content) return null;
+        var match;
+        match = content.match(/^<bobot-remind>([\s\S]*)<\/bobot-remind>$/);
+        if (match) return { type: 'reminder', content: match[1] };
+        match = content.match(/^<bobot-cron>([\s\S]*)<\/bobot-cron>$/);
+        if (match) return { type: 'cron', content: match[1] };
+        return null;
+    },
+
+    renderScheduledMessage(parsed) {
+        var wrapper = document.createElement('div');
+        wrapper.className = 'message-scheduled message-scheduled--' + parsed.type;
+
+        var labelEl = document.createElement('div');
+        labelEl.className = 'message-scheduled-label';
+        if (parsed.type === 'reminder') {
+            labelEl.textContent = '\uD83D\uDD14 Reminder';
+        } else {
+            labelEl.textContent = '\u23F0 Scheduled';
+        }
+        wrapper.appendChild(labelEl);
+
+        var contentEl = document.createElement('div');
+        contentEl.className = 'message-scheduled-content';
+        contentEl.textContent = parsed.content;
+        wrapper.appendChild(contentEl);
+
+        return wrapper;
+    },
+
     resetConfirmingButtons() {
         document.querySelectorAll('.bobot-action-btn--confirming').forEach(function(btn) {
             btn.classList.remove('bobot-action-btn--confirming');

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -961,3 +961,39 @@ header {
   opacity: var(--opacities-disabled);
   cursor: default;
 }
+
+/* Scheduled message components (reminders & cron) */
+.message-scheduled {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.message-scheduled-label {
+  font-size: var(--font-sizes-0);
+  font-weight: var(--font-weights-bold);
+  letter-spacing: var(--letter-spacings-wide);
+  text-transform: uppercase;
+}
+
+.message-scheduled-content {
+  line-height: var(--line-heights-normal);
+}
+
+.message-scheduled--reminder .message-scheduled-label {
+  color: #fe640b;
+}
+
+.message:has(.message-scheduled--reminder) {
+  background: #fef0e4;
+  border-left: 3px solid #fe640b;
+}
+
+.message-scheduled--cron .message-scheduled-label {
+  color: #179299;
+}
+
+.message:has(.message-scheduled--cron) {
+  background: #e0f5f5;
+  border-left: 3px solid #179299;
+}

--- a/web/static/topic_chat.js
+++ b/web/static/topic_chat.js
@@ -169,7 +169,12 @@ window.TopicChatClient = class TopicChatClient {
                 this.wsContainer.send({ content: msg, topic_id: this.topicId });
             }, !!id);
         } else {
-            contentEl.textContent = content;
+            var scheduled = MessageRenderer.parseScheduledMessage(content);
+            if (scheduled) {
+                contentEl.appendChild(MessageRenderer.renderScheduledMessage(scheduled));
+            } else {
+                contentEl.textContent = content;
+            }
             msgEl.appendChild(contentEl);
         }
 
@@ -261,7 +266,12 @@ window.TopicChatClient = class TopicChatClient {
                 this.wsContainer.send({ content: msg, topic_id: this.topicId });
             }, true);
         } else {
-            contentEl.textContent = content;
+            var scheduled = MessageRenderer.parseScheduledMessage(content);
+            if (scheduled) {
+                contentEl.appendChild(MessageRenderer.renderScheduledMessage(scheduled));
+            } else {
+                contentEl.textContent = content;
+            }
             msgEl.appendChild(contentEl);
         }
 


### PR DESCRIPTION
## Summary
- Parse `<bobot-remind>` and `<bobot-cron>` XML tags in user messages on the client side
- Render them as visually distinct bubbles with emoji icons, labels, and color accents instead of showing raw tag text
- Reminders get a bell emoji, "Reminder" label, and warm peach accent
- Cron messages get a clock emoji, "Scheduled" label, and cool teal accent

## Changes
| File | Change |
|------|--------|
| `web/static/message-renderer.js` | Added `parseScheduledMessage()` and `renderScheduledMessage()` methods |
| `web/static/chat.js` | Modified `addMessage()` and `prependMessage()` to detect scheduled messages |
| `web/static/topic_chat.js` | Same changes for topic chat |
| `web/static/style.css` | Added `.message-scheduled` component styles with Catppuccin-palette accents |

## Test plan
- [ ] Send a reminder via `/remind` and verify it renders with bell icon and peach accent
- [ ] Create a cron job and verify its messages render with clock icon and teal accent
- [ ] Verify regular user messages still render as plain text
- [ ] Verify reminder/cron messages in chat history render correctly on page reload
- [ ] Test in both private chat and topic chat views

🤖 Generated with [Claude Code](https://claude.com/claude-code)