### PR TITLE
Rename topics to chats throughout application

### DIFF
--- a/server/chat.go
+++ b/server/chat.go
@@ -228,7 +228,7 @@ func (s *Server) pushToTopicMembers(topicID, senderID int64, senderName, content
 				continue
 			}
 			title := fmt.Sprintf("%s in #%s", senderName, topic.Name)
-			payload := push.BuildPayload(title, push.TruncateMessage(content, 200), fmt.Sprintf("/topics/%d", topicID), fmt.Sprintf("msg-topic-%d", topicID))
+			payload := push.BuildPayload(title, push.TruncateMessage(content, 200), fmt.Sprintf("/chats/%d", topicID), fmt.Sprintf("msg-topic-%d", topicID))
 			go s.pushSender.NotifyUser(member.UserID, payload)
 		}
 	}

--- a/server/pages.go
+++ b/server/pages.go
@@ -13,7 +13,7 @@ import (
 	"github.com/esnunes/bobot/web"
 )
 
-var navigatePathRe = regexp.MustCompile(`^/topics/\d+$`)
+var navigatePathRe = regexp.MustCompile(`^/chats/\d+$`)
 
 type TopicView struct {
 	ID          int64
@@ -149,11 +149,11 @@ func (s *Server) loadTemplates() error {
 	}
 	s.templates["chat"] = chatTmpl
 
-	topicsTmpl, err := template.ParseFS(web.FS, "templates/layout.html", "templates/topics.html")
+	chatsTmpl, err := template.ParseFS(web.FS, "templates/layout.html", "templates/chats.html")
 	if err != nil {
 		return err
 	}
-	s.templates["topics"] = topicsTmpl
+	s.templates["chats"] = chatsTmpl
 
 	topicChatTmpl, err := template.ParseFS(web.FS, "templates/layout.html", "templates/topic_chat.html")
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *Server) loadTemplates() error {
 }
 
 // validateNavigatePath returns a safe navigation path.
-// Only /chat and /topics/{id} are allowed; anything else defaults to /chat.
+// Only /chat and /chats/{id} are allowed; anything else defaults to /chat.
 func validateNavigatePath(path string) string {
 	if path == "/chat" || path == "/schedules" || strings.HasPrefix(path, "/schedules?") || path == "/admin" || strings.HasPrefix(path, "/admin/") || navigatePathRe.MatchString(path) {
 		return path
@@ -322,7 +322,7 @@ func (s *Server) handleChatPage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) handleTopicsPage(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleChatsPage(w http.ResponseWriter, r *http.Request) {
 	userData := auth.UserDataFromContext(r.Context())
 
 	topics, err := s.db.GetUserTopics(userData.UserID)
@@ -341,7 +341,7 @@ func (s *Server) handleTopicsPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	s.render(w, "topics", PageData{Title: "Topics", Topics: topicViews})
+	s.render(w, "chats", PageData{Title: "Chats", Topics: topicViews})
 }
 
 func (s *Server) handleTopicChatPage(w http.ResponseWriter, r *http.Request) {

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -156,7 +156,7 @@ func (p *ChatPipeline) pushToTopicMembers(topicID, senderID int64, senderName, c
 				continue
 			}
 			title := fmt.Sprintf("%s in #%s", senderName, topic.Name)
-			payload := push.BuildPayload(title, push.TruncateMessage(content, 200), fmt.Sprintf("/topics/%d", topicID), fmt.Sprintf("msg-topic-%d", topicID))
+			payload := push.BuildPayload(title, push.TruncateMessage(content, 200), fmt.Sprintf("/chats/%d", topicID), fmt.Sprintf("msg-topic-%d", topicID))
 			go p.pushSender.NotifyUser(member.UserID, payload)
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -135,8 +135,8 @@ func (s *Server) routes() {
 	s.router.HandleFunc("GET /signup", s.handleSignupPage)
 	s.router.HandleFunc("POST /signup", s.handleSignupPage)
 	s.router.HandleFunc("GET /chat", s.sessionMiddleware(s.handleChatPage))
-	s.router.HandleFunc("GET /topics", s.sessionMiddleware(s.handleTopicsPage))
-	s.router.HandleFunc("GET /topics/{id}", s.sessionMiddleware(s.handleTopicChatPage))
+	s.router.HandleFunc("GET /chats", s.sessionMiddleware(s.handleChatsPage))
+	s.router.HandleFunc("GET /chats/{id}", s.sessionMiddleware(s.handleTopicChatPage))
 
 	// Service worker (must be served at root scope)
 	s.router.HandleFunc("GET /sw.js", func(w http.ResponseWriter, r *http.Request) {

--- a/server/topics.go
+++ b/server/topics.go
@@ -37,7 +37,7 @@ func (s *Server) handleCreateTopic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("HX-Trigger", `{"bobot:redirect": {"path": "/topics/`+strconv.FormatInt(topic.ID, 10)+`"}}`)
+	w.Header().Set("HX-Trigger", `{"bobot:redirect": {"path": "/chats/`+strconv.FormatInt(topic.ID, 10)+`"}}`)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/topics_test.go
+++ b/server/topics_test.go
@@ -51,7 +51,7 @@ func TestCreateTopic(t *testing.T) {
 
 	// HTMX pattern: trigger client-side redirect
 	trigger := w.Header().Get("HX-Trigger")
-	expectedTrigger := `{"bobot:redirect": {"path": "/topics/1"}}`
+	expectedTrigger := `{"bobot:redirect": {"path": "/chats/1"}}`
 	if trigger != expectedTrigger {
 		t.Errorf("expected HX-Trigger %q, got %q", expectedTrigger, trigger)
 	}

--- a/web/static/push.js
+++ b/web/static/push.js
@@ -140,8 +140,8 @@
   }
 
   function navigateTo(url) {
-    // Validate path — only allow /chat and /topics/{id}
-    if (url !== "/chat" && !/^\/topics\/\d+$/.test(url)) return;
+    // Validate path — only allow /chat and /chats/{id}
+    if (url !== "/chat" && !/^\/chats\/\d+$/.test(url)) return;
 
     if (typeof htmx === "undefined") {
       console.log("htmx not loaded");

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -513,14 +513,14 @@ header {
 }
 
 /* ============================================
-   TOPICS PAGE
+   CHATS PAGE
    ============================================ */
-.topics-container {
+.chats-container {
   display: flex;
   flex-direction: column;
 }
 
-.topics-list {
+.chats-list {
   flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
@@ -528,6 +528,39 @@ header {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+}
+
+.bobot-chat-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--colors-surface);
+  border-radius: var(--radii-lg);
+  box-shadow: var(--shadows-low);
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow var(--transitions-fast);
+  border: 0;
+}
+
+.bobot-chat-item:hover {
+  box-shadow: var(--shadows-medium);
+}
+
+.bobot-icon {
+  width: var(--sizes-icon);
+  height: var(--sizes-icon);
+  color: var(--colors-text-secondary);
+  flex-shrink: 0;
+}
+
+.section-label {
+  font-size: var(--font-sizes-0);
+  color: var(--colors-text-secondary);
+  font-weight: var(--font-weights-medium);
+  padding-left: var(--space-1);
+  margin-top: var(--space-1);
 }
 
 .topic-item {

--- a/web/static/topic_chat.js
+++ b/web/static/topic_chat.js
@@ -293,7 +293,7 @@ window.TopicChatClient = class TopicChatClient {
 
             if (!resp.ok) throw new Error('Failed to leave topic');
 
-            htmx.ajax('GET', '/topics', {target: 'body', swap: 'innerHTML'});
+            htmx.ajax('GET', '/chats', {target: 'body', swap: 'innerHTML'});
         } catch (err) {
             console.error('Failed to leave topic:', err);
             alert('Failed to leave topic');
@@ -311,7 +311,7 @@ window.TopicChatClient = class TopicChatClient {
 
             if (!resp.ok) throw new Error('Failed to delete topic');
 
-            htmx.ajax('GET', '/topics', {target: 'body', swap: 'innerHTML'});
+            htmx.ajax('GET', '/chats', {target: 'body', swap: 'innerHTML'});
         } catch (err) {
             console.error('Failed to delete topic:', err);
             alert('Failed to delete topic');

--- a/web/templates/chat.html
+++ b/web/templates/chat.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="chat-container" data-page="chat">
     <header>
-        <button hx-get="/topics" hx-target="body" aria-label="Topics"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></button>
+        <button hx-get="/chats" hx-target="body" aria-label="Chats"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></button>
         <h1>bobot</h1>
         <button id="menu-btn" aria-label="Menu"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
     </header>

--- a/web/templates/chats.html
+++ b/web/templates/chats.html
@@ -1,15 +1,20 @@
 {{define "content"}}
-<div class="topics-container" data-page="topics">
+<div class="chats-container" data-page="chats">
     <header>
-        <button hx-get="/chat" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
-        <h1>Topics</h1>
+        <div></div>
+        <h1>Chats</h1>
         <button id="menu-btn" aria-label="Menu"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
     </header>
 
-    <main class="topics-list">
+    <main class="chats-list">
+        <button hx-get="/chat" hx-target="body" class="bobot-chat-item">
+            <svg class="bobot-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
+            <span class="topic-name">bobot</span>
+        </button>
+        <div class="section-label">Topics</div>
         {{if .Topics}}
             {{range .Topics}}
-            <button hx-get="/topics/{{.ID}}" hx-target="body" class="topic-item">
+            <button hx-get="/chats/{{.ID}}" hx-target="body" class="topic-item">
                 <span class="topic-name">{{.Name}}</span>
                 <span class="topic-members">{{.MemberCount}} member{{if ne .MemberCount 1}}s{{end}}</span>
             </button>

--- a/web/templates/schedules.html
+++ b/web/templates/schedules.html
@@ -2,7 +2,7 @@
 <div class="skills-container" data-page="schedules">
     <header>
         {{if .TopicID}}
-        <button hx-get="/topics/{{.TopicID}}" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <button hx-get="/chats/{{.TopicID}}" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
         {{else}}
         <button hx-get="/chat" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
         {{end}}

--- a/web/templates/skills.html
+++ b/web/templates/skills.html
@@ -2,7 +2,7 @@
 <div class="skills-container" data-page="skills">
     <header>
         {{if .TopicID}}
-        <button hx-get="/topics/{{.TopicID}}" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <button hx-get="/chats/{{.TopicID}}" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
         {{else}}
         <button hx-get="/chat" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
         {{end}}

--- a/web/templates/topic_chat.html
+++ b/web/templates/topic_chat.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="chat-container" data-page="topic-chat" data-topic-id="{{.TopicID}}" data-owner-id="{{.OwnerID}}" data-current-user-id="{{.CurrentUserID}}">
     <header>
-        <button hx-get="/topics" hx-target="body" aria-label="Back"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <button hx-get="/chats" hx-target="body" aria-label="Chats"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></button>
         <h1 id="topic-name">{{.TopicName}}</h1>
         <button id="menu-btn" aria-label="Menu"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
     </header>


### PR DESCRIPTION
## Summary
This PR renames the "topics" feature to "chats" across the entire application for improved clarity and consistency in terminology.

## Key Changes
- **Route updates**: Changed `/topics` endpoints to `/chats` in server routing and client-side navigation
- **Template renaming**: Renamed `topics.html` to `chats.html` with updated class names and labels
- **CSS refactoring**: Updated stylesheet to use `.chats-container` and `.chats-list` instead of `.topics-container` and `.topics-list`
- **New UI components**: Added `.bobot-chat-item` styling and `.section-label` for improved visual hierarchy in the chats list
- **Handler renaming**: Renamed `handleTopicsPage` to `handleChatsPage` in server code
- **Navigation updates**: Updated all navigation buttons and links to reference `/chats` instead of `/topics`
- **Push notifications**: Updated notification payload URLs to use `/chats/{id}` paths
- **Client-side validation**: Updated path validation regex in `push.js` to match new `/chats/{id}` pattern
- **Test updates**: Updated test expectations to reflect new redirect paths

## Implementation Details
- The underlying data model and database queries remain unchanged; only the presentation layer and routing have been updated
- The chats list now displays a "bobot" chat item at the top with a section label "Topics" for topic-based chats below
- All HTMX triggers and client-side navigation have been updated to use the new `/chats` routes
- The change maintains backward compatibility in terms of functionality while improving user-facing terminology

https://claude.ai/code/session_01CMwK2UaTwuhiKTLsEmd5Ja