### PR TITLE
Fix ThinQ API display light control for air conditioners

### DIFF
--- a/docs/plans/2026-02-08-thinq-tool-design.md
+++ b/docs/plans/2026-02-08-thinq-tool-design.md
@@ -150,8 +150,8 @@ CREATE TABLE IF NOT EXISTS device_states (
 | `mode: dry` | `{"airConJobMode": {"currentJobMode": "AIR_DRY"}}` |
 | `mode: fan` | `{"airConJobMode": {"currentJobMode": "FAN"}}` |
 | `fan_speed: <value>` | `{"airFlow": {"windStrength": "<VALUE>"}}` |
-| `display: on` | `{"display": {"displayLight": "DISPLAY_ON"}}` |
-| `display: off` | `{"display": {"displayLight": "DISPLAY_OFF"}}` |
+| `display: on` | `{"display": {"light": "ON"}}` |
+| `display: off` | `{"display": {"light": "OFF"}}` |
 
 Multiple settings can be combined in a single `set` command. Parameters are merged into one control payload.
 

--- a/tools/thinq/thinq.go
+++ b/tools/thinq/thinq.go
@@ -287,11 +287,11 @@ func (t *ThinqTool) execSet(input map[string]any) (string, error) {
 	}
 
 	if display, ok := input["display"].(string); ok {
-		val := "DISPLAY_ON"
+		val := "ON"
 		if display == "off" {
-			val = "DISPLAY_OFF"
+			val = "OFF"
 		}
-		cmd["display"] = map[string]any{"displayLight": val}
+		cmd["display"] = map[string]any{"light": val}
 	}
 
 	if len(cmd) == 0 {
@@ -353,7 +353,7 @@ func formatState(deviceID string, state map[string]any) string {
 		}
 	}
 	if disp, ok := state["display"].(map[string]any); ok {
-		if dl, ok := disp["displayLight"].(string); ok {
+		if dl, ok := disp["light"].(string); ok {
 			sb.WriteString(fmt.Sprintf("Display: %s\n", dl))
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixed incorrect property key in display control payload (`displayLight` → `light`)
- Fixed incorrect enum values (`DISPLAY_ON`/`DISPLAY_OFF` → `ON`/`OFF`)
- Updated both the control command and state formatting to use correct API schema

## Test plan
- [x] All existing ThinQ tool tests pass
- [x] Verify display on/off commands work against a real air conditioner

🤖 Generated with [Claude Code](https://claude.com/claude-code)