### PR TITLE
feat: add terms of service page

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -231,6 +231,25 @@
   "privacy.contact_title": "Contact",
   "privacy.contact_description": "For questions about this privacy policy, contact the administrator of your bobot instance.",
 
+  "tos.title": "Terms of Service",
+  "tos.last_updated": "Last updated: February 26, 2026",
+  "tos.intro": "By using bobot (\"Service\"), you agree to the following:",
+  "tos.risk_title": "1. Use at Your Own Risk",
+  "tos.risk_description": "The Service provides AI-generated responses and may be incorrect or incomplete. Do not rely on it for medical, legal, financial, or safety-critical decisions.",
+  "tos.guarantees_title": "2. No Guarantees",
+  "tos.guarantees_description": "The Service is provided \"as is\" without warranties of any kind. We do not guarantee accuracy, availability, or fitness for any purpose.",
+  "tos.responsibility_title": "3. User Responsibility",
+  "tos.responsibility_description": "You agree not to use the Service for illegal, harmful, abusive, or misleading activities.",
+  "tos.privacy_title": "4. Privacy",
+  "tos.privacy_description": "Your messages may be stored and used to operate and improve the Service. Do not share sensitive personal information. See our Privacy Policy for details.",
+  "tos.liability_title": "5. Limitation of Liability",
+  "tos.liability_description": "To the fullest extent permitted by law, we are not liable for any damages resulting from your use of the Service.",
+  "tos.changes_title": "6. Changes",
+  "tos.changes_description": "We may update these terms at any time. Continued use of the Service means you accept the updated terms.",
+  "tos.disagree": "If you do not agree with these terms, do not use the Service.",
+
+  "landing.tos_link": "Terms of Service",
+
   "lang.en": "English",
   "lang.pt-BR": "Portugu\u00eas (Brasil)"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -231,6 +231,25 @@
   "privacy.contact_title": "Contato",
   "privacy.contact_description": "Para d\u00favidas sobre esta pol\u00edtica de privacidade, entre em contato com o administrador da sua inst\u00e2ncia do bobot.",
 
+  "tos.title": "Termos de Servi\u00e7o",
+  "tos.last_updated": "\u00daltima atualiza\u00e7\u00e3o: 26 de fevereiro de 2026",
+  "tos.intro": "Ao usar o bobot (\"Servi\u00e7o\"), voc\u00ea concorda com o seguinte:",
+  "tos.risk_title": "1. Use por Sua Conta e Risco",
+  "tos.risk_description": "O Servi\u00e7o fornece respostas geradas por IA e pode estar incorreto ou incompleto. N\u00e3o dependa dele para decis\u00f5es m\u00e9dicas, legais, financeiras ou cr\u00edticas de seguran\u00e7a.",
+  "tos.guarantees_title": "2. Sem Garantias",
+  "tos.guarantees_description": "O Servi\u00e7o \u00e9 fornecido \"como est\u00e1\" sem garantias de qualquer tipo. N\u00e3o garantimos precis\u00e3o, disponibilidade ou adequa\u00e7\u00e3o para qualquer finalidade.",
+  "tos.responsibility_title": "3. Responsabilidade do Usu\u00e1rio",
+  "tos.responsibility_description": "Voc\u00ea concorda em n\u00e3o usar o Servi\u00e7o para atividades ilegais, prejudiciais, abusivas ou enganosas.",
+  "tos.privacy_title": "4. Privacidade",
+  "tos.privacy_description": "Suas mensagens podem ser armazenadas e usadas para operar e melhorar o Servi\u00e7o. N\u00e3o compartilhe informa\u00e7\u00f5es pessoais sens\u00edveis. Consulte nossa Pol\u00edtica de Privacidade para detalhes.",
+  "tos.liability_title": "5. Limita\u00e7\u00e3o de Responsabilidade",
+  "tos.liability_description": "Na m\u00e1xima extens\u00e3o permitida por lei, n\u00e3o somos respons\u00e1veis por quaisquer danos resultantes do seu uso do Servi\u00e7o.",
+  "tos.changes_title": "6. Altera\u00e7\u00f5es",
+  "tos.changes_description": "Podemos atualizar estes termos a qualquer momento. O uso continuado do Servi\u00e7o significa que voc\u00ea aceita os termos atualizados.",
+  "tos.disagree": "Se voc\u00ea n\u00e3o concorda com estes termos, n\u00e3o use o Servi\u00e7o.",
+
+  "landing.tos_link": "Termos de Servi\u00e7o",
+
   "lang.en": "English",
   "lang.pt-BR": "Portugu\u00eas (Brasil)"
 }

--- a/server/pages.go
+++ b/server/pages.go
@@ -236,6 +236,7 @@ func (s *Server) loadTemplates() error {
 	templateDefs := map[string]string{
 		"landing":           "templates/landing.html",
 		"privacy":           "templates/privacy.html",
+		"tos":               "templates/tos.html",
 		"login":             "templates/login.html",
 		"signup":            "templates/signup.html",
 		"chats":             "templates/chats.html",
@@ -289,6 +290,10 @@ func (s *Server) handleLandingPage(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePrivacyPage(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "privacy", PageData{Title: "Privacy Policy"})
+}
+
+func (s *Server) handleTosPage(w http.ResponseWriter, r *http.Request) {
+	s.render(w, r, "tos", PageData{Title: "Terms of Service"})
 }
 
 func (s *Server) handleLoginPage(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -153,6 +153,7 @@ func (s *Server) routes() {
 	s.router.HandleFunc("GET /login", s.handleLoginPage)
 	s.router.HandleFunc("POST /login", s.handleLoginPage)
 	s.router.HandleFunc("GET /privacy", s.handlePrivacyPage)
+	s.router.HandleFunc("GET /tos", s.handleTosPage)
 	s.router.HandleFunc("POST /logout", s.handleLogout)
 	s.router.HandleFunc("GET /signup", s.handleSignupPage)
 	s.router.HandleFunc("POST /signup", s.handleSignupPage)

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -24,6 +24,7 @@
 
     <div class="landing-actions">
         <a href="/login" hx-get="/login" hx-target="body" hx-swap="innerHTML" class="landing-btn landing-btn-primary">{{t .Lang "landing.login"}}</a>
+        <a href="/tos" class="landing-btn landing-btn-secondary">{{t .Lang "landing.tos_link"}}</a>
         <a href="/privacy" class="landing-btn landing-btn-secondary">{{t .Lang "landing.privacy_link"}}</a>
     </div>
 </div>

--- a/web/templates/tos.html
+++ b/web/templates/tos.html
@@ -1,0 +1,31 @@
+{{define "content"}}
+<div class="privacy-container">
+    <h1>{{t .Lang "tos.title"}}</h1>
+    <p><em>{{t .Lang "tos.last_updated"}}</em></p>
+    <p>{{t .Lang "tos.intro"}}</p>
+
+    <h2>{{t .Lang "tos.risk_title"}}</h2>
+    <p>{{t .Lang "tos.risk_description"}}</p>
+
+    <h2>{{t .Lang "tos.guarantees_title"}}</h2>
+    <p>{{t .Lang "tos.guarantees_description"}}</p>
+
+    <h2>{{t .Lang "tos.responsibility_title"}}</h2>
+    <p>{{t .Lang "tos.responsibility_description"}}</p>
+
+    <h2>{{t .Lang "tos.privacy_title"}}</h2>
+    <p>{{t .Lang "tos.privacy_description"}}</p>
+
+    <h2>{{t .Lang "tos.liability_title"}}</h2>
+    <p>{{t .Lang "tos.liability_description"}}</p>
+
+    <h2>{{t .Lang "tos.changes_title"}}</h2>
+    <p>{{t .Lang "tos.changes_description"}}</p>
+
+    <p>{{t .Lang "tos.disagree"}}</p>
+
+    <div class="privacy-back">
+        <a href="/">&#8592; {{t .Lang "landing.title"}}</a>
+    </div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
- Add a Terms of Service page at `/tos` with full i18n support (English and Portuguese)
- Link ToS from the landing page between the Login and Privacy Policy buttons
- Reuses the existing privacy page layout and styling for consistency

## Test plan
- [ ] Visit `/tos` directly and verify the page renders correctly
- [ ] Visit `/` (landing page) and verify the "Terms of Service" button appears between Login and Privacy Policy
- [ ] Switch browser language to Portuguese and verify translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)