### PR TITLE
feat(calendar): show full event details in list output

### DIFF
--- a/docs/plans/2026-03-09-feat-calendar-full-event-details-plan.md
+++ b/docs/plans/2026-03-09-feat-calendar-full-event-details-plan.md
@@ -1,0 +1,73 @@
+---
+title: "Show full event details in calendar list output"
+type: feat
+date: 2026-03-09
+issue: https://github.com/esnunes/bobot/issues/50
+---
+
+# Show Full Event Details in Calendar List Output
+
+## Overview
+
+The calendar tool's `list` command only shows event title, time, location, and ID. The `EventInfo` struct already fetches description, location, and HTML link from the Google Calendar API — but `execList()` doesn't include them in the output. Additionally, location may not be appearing despite code that checks for it.
+
+## Proposed Solution
+
+Update the `execList()` output formatting in `tools/calendar/calendar.go` to include description, Google Calendar link, and fix location display. All three fields are already available in the `EventInfo` struct — this is purely an output formatting change.
+
+## Acceptance Criteria
+
+- [x] Event description is displayed in full (not truncated) when present
+- [x] Google Calendar HTML link is displayed when present
+- [x] Location is reliably displayed when present on an event
+- [x] Empty fields are not shown (no empty labels)
+- [x] Existing output format (title, time, ID) is preserved
+
+## Implementation
+
+### 1. Investigate location bug
+
+**File:** `tools/calendar/client.go` — `eventToInfo()` function
+
+The current code maps `Location: e.Location` directly from the Google API response. The `execList()` code checks `e.Location != ""` and appends it. Verify:
+- Is the Google Calendar API actually returning location data? (Add temporary logging or inspect API response)
+- Is there a field mapping issue in `eventToInfo()`?
+- Are test events actually populated with location in Google Calendar?
+
+If location is correctly mapped but events simply lack location data, no code fix is needed — just confirm it works when location exists.
+
+### 2. Update `execList()` output formatting
+
+**File:** `tools/calendar/calendar.go` — `execList()` method (lines ~211-228)
+
+Current format per event:
+```
+- **Meeting Title** (Mon Mar 9, 2:30 PM - Mon Mar 9, 3:30 PM) @ Location [ID: abc123]
+```
+
+Updated format per event (all optional fields shown only when non-empty):
+```
+- **Meeting Title** (Mon Mar 9, 2:30 PM - Mon Mar 9, 3:30 PM) [ID: abc123]
+  Location: Conference Room A
+  Description: Weekly team sync to discuss project status
+  Link: https://calendar.google.com/calendar/event?eid=abc123
+```
+
+Changes to the formatting loop in `execList()`:
+- Keep the first line as-is (title + time + ID)
+- After the first line, conditionally append indented lines for Location, Description, and Link
+- Only show each field when its value is non-empty
+- Add a blank line between events for readability when details are present
+
+### 3. Test
+
+- Test with events that have all three fields populated
+- Test with events missing some/all optional fields (no empty labels should appear)
+- Test with all-day events
+- Verify the output reads well for the LLM (since this is tool output consumed by the assistant)
+
+## References
+
+- `tools/calendar/calendar.go:211-228` — current `execList()` formatting
+- `tools/calendar/client.go:26-35` — `EventInfo` struct (already has Description, HTMLLink)
+- `tools/calendar/client.go:220-246` — `eventToInfo()` mapping

--- a/docs/solutions/logic-errors/calendar-list-missing-event-details.md
+++ b/docs/solutions/logic-errors/calendar-list-missing-event-details.md
@@ -1,0 +1,82 @@
+---
+title: "Calendar list command missing description, link, and location in output"
+date: 2026-03-09
+category: logic-errors
+module: calendar
+tags:
+  - formatting
+  - calendar
+  - google-calendar
+  - tool-output
+severity: low
+time_to_resolve: 15m
+---
+
+# Calendar List Missing Event Details
+
+## Problem
+
+The calendar tool's `execList()` function produced a single-line output per event that omitted two fields entirely — **Description** and **HTMLLink** (the Google Calendar link) — and displayed **Location** inline with an `@ ` prefix on the same line as the event title and time.
+
+Even though the `EventInfo` struct (`client.go:26-35`) carried all three fields and `eventToInfo()` (`client.go:220-246`) populated them from the Google Calendar API, the list formatting code never rendered `Description` or `HTMLLink`.
+
+**Symptoms:**
+- Events listed with no description text, even when the Google Calendar event had one
+- No Google Calendar link in the output
+- Location shown inline as `@ Some Place`, easily missed with long location strings
+
+## Root Cause
+
+The fields were correctly fetched from the Google Calendar API and stored in `EventInfo`. The problem was purely in the **display/formatting layer** inside `execList()`. There were no conditional blocks for `e.Description` or `e.HTMLLink`, so those fields were silently discarded during output generation. The data was available; it was never rendered.
+
+## Solution
+
+Updated the formatting loop in `execList()` (`calendar.go:215-233`) to add indented detail lines for Location, Description, and Link — each shown only when non-empty.
+
+**Before:**
+
+```go
+if e.Location != "" {
+    sb.WriteString(fmt.Sprintf(" @ %s", e.Location))
+}
+sb.WriteString(fmt.Sprintf(" [ID: %s]", e.ID))
+sb.WriteString("\n")
+```
+
+**After:**
+
+```go
+sb.WriteString(fmt.Sprintf(" [ID: %s]\n", e.ID))
+if e.Location != "" {
+    sb.WriteString(fmt.Sprintf("  Location: %s\n", e.Location))
+}
+if e.Description != "" {
+    sb.WriteString(fmt.Sprintf("  Description: %s\n", e.Description))
+}
+if e.HTMLLink != "" {
+    sb.WriteString(fmt.Sprintf("  Link: %s\n", e.HTMLLink))
+}
+```
+
+## Investigation Notes
+
+Location handling was **not a bug** — the original code correctly checked `e.Location != ""` and rendered it when present. It used an inline format (`@ Place`) rather than a dedicated detail line. The change was a formatting improvement for consistency, not a correctness fix.
+
+## Prevention
+
+**If you fetch it and store it, you must render it — unused struct fields are silent bugs.**
+
+When implementing output formatting for a struct:
+1. Compare every populated struct field against the output function — each field should either appear in the output or have an explicit reason for omission
+2. Write output-driven tests that assert the formatted string contains values for all non-empty fields
+3. Trace API-to-output as a single pipeline: Fetch → Store → Render. If steps 1-2 include fields that step 3 does not, that's a gap
+
+The indented `Key: Value` detail-line pattern used here is consistent with other tools in the codebase (Spotify `execPlaybackStatus`, web search, cron).
+
+## References
+
+- **Issue:** [#50 - Show full event details in calendar list output](https://github.com/esnunes/bobot/issues/50)
+- **PR:** [#51 - feat(calendar): show full event details in list output](https://github.com/esnunes/bobot/pull/51)
+- **Plan:** `docs/plans/2026-03-09-feat-calendar-full-event-details-plan.md`
+- **Original calendar plan:** `docs/plans/2026-02-26-feat-google-calendar-integration-plan.md`
+- **Similar pattern:** `tools/spotify/spotify.go` — `execPlaybackStatus()` uses the same indented detail-line format

--- a/tools/calendar/calendar.go
+++ b/tools/calendar/calendar.go
@@ -220,11 +220,16 @@ func (t *CalendarTool) execList(ctx context.Context, ts oauth2.TokenSource, cal 
 			end := formatEventTime(e.End)
 			sb.WriteString(fmt.Sprintf("- **%s** (%s - %s)", e.Title, start, end))
 		}
+		sb.WriteString(fmt.Sprintf(" [ID: %s]\n", e.ID))
 		if e.Location != "" {
-			sb.WriteString(fmt.Sprintf(" @ %s", e.Location))
+			sb.WriteString(fmt.Sprintf("  Location: %s\n", e.Location))
 		}
-		sb.WriteString(fmt.Sprintf(" [ID: %s]", e.ID))
-		sb.WriteString("\n")
+		if e.Description != "" {
+			sb.WriteString(fmt.Sprintf("  Description: %s\n", e.Description))
+		}
+		if e.HTMLLink != "" {
+			sb.WriteString(fmt.Sprintf("  Link: %s\n", e.HTMLLink))
+		}
 	}
 
 	return sb.String(), nil


### PR DESCRIPTION
## Summary
- Include event description, Google Calendar link, and location as indented detail lines in the calendar list output
- Fields only shown when they have a value (no empty labels)
- Location was already supported but appeared inline — now displayed consistently as a detail line

Closes #50

## Changes

**`tools/calendar/calendar.go`** — Updated `execList()` formatting loop to add Description, Location, and Link as indented lines below each event's title/time line.

Before:
```
- **Meeting** (Mon Mar 9, 2:30 PM - Mon Mar 9, 3:30 PM) @ Office [ID: abc123]
```

After:
```
- **Meeting** (Mon Mar 9, 2:30 PM - Mon Mar 9, 3:30 PM) [ID: abc123]
  Location: Office
  Description: Weekly team sync
  Link: https://calendar.google.com/calendar/event?eid=abc123
```

## Testing
- All project tests pass (`go test ./...`)
- Build passes (`go build ./...`)
- No code changes to API client — `EventInfo` struct already fetched all three fields
- Location investigation: code was correct, location displays when present on the event

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: output-only change to calendar tool formatting — no new API calls, database changes, or error paths introduced.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)