### PR TITLE
feat(calendar): add recurring event support

### DIFF
--- a/docs/plans/2026-03-09-feat-recurring-calendar-events-plan.md
+++ b/docs/plans/2026-03-09-feat-recurring-calendar-events-plan.md
@@ -1,0 +1,382 @@
+---
+title: "feat: Add recurring event support to the calendar tool"
+type: feat
+date: 2026-03-09
+issue: https://github.com/esnunes/bobot/issues/52
+---
+
+# feat: Add recurring event support to the calendar tool
+
+## Overview
+
+Extend the calendar tool to support creating, updating, and deleting recurring events via Google Calendar API. The LLM translates natural language recurrence descriptions (e.g., "every Tuesday") into iCal RRULE strings. Update and delete operations support three scopes: single instance, all instances, and this-and-future. Listing continues to work as-is since `SingleEvents(true)` already expands recurring events.
+
+## Problem Statement / Motivation
+
+The calendar tool only supports one-time events. Users cannot create events that repeat on a schedule (weekly standups, monthly reviews, daily reminders). This forces manual creation of each occurrence, defeating the purpose of an AI assistant managing the calendar. Recurring events already display correctly in list output (Google Calendar expands them), but there is no way to create, update, or delete them with recurrence awareness.
+
+## Proposed Solution
+
+Add a `recurrence` parameter to the create command and a `scope` parameter to update/delete commands. Extend `EventInfo` with recurrence metadata so the LLM can distinguish recurring from non-recurring events. The tool handles master-vs-instance ID resolution internally, so the LLM only needs to pass event IDs from list results.
+
+## Technical Approach
+
+### Key Design Decisions
+
+1. **Default scope is `single`** -- least destructive option when the LLM or user doesn't specify scope
+2. **Tool derives master ID from instance ID internally** -- the LLM passes whatever event ID it has; the tool strips `_{timestamp}` suffix when `scope=all`
+3. **Basic RRULE validation server-side** -- verify `RRULE:` prefix and `FREQ=` presence; let Google API handle detailed validation; map 400 errors to user-friendly messages
+4. **Accept single RRULE string** -- wrap as `[]string{recurrence}` for Google API internally; EXDATE/RDATE are managed through scope operations, not user input
+5. **Rollback for this-and-future** -- if step 2 (create new series) fails, attempt to restore original RRULE on master; log if restore also fails
+6. **LLM should ask for clarification on ambiguous scope** -- documented in tool description
+
+### Architecture
+
+No new packages or databases. All changes are within `tools/calendar/`:
+
+```
+tools/calendar/
+  calendar.go  -- Schema(), Description(), ParseArgs(), Execute(), exec* handlers
+  client.go    -- EventInfo struct, CreateEvent, UpdateEvent, DeleteEvent, eventToInfo, new helpers
+```
+
+### Implementation Phases
+
+#### Phase 1: EventInfo and client.go updates
+
+Extend the data model and API client to support recurrence.
+
+**`client.go` -- EventInfo struct** (line 26):
+
+```go
+type EventInfo struct {
+	ID               string
+	Title            string
+	Description      string
+	Location         string
+	Start            string
+	End              string
+	AllDay           bool
+	HTMLLink         string
+	// New fields for recurrence
+	IsRecurring      bool
+	RecurringEventID string   // master event ID (populated on instances)
+	Recurrence       []string // RRULE strings (populated on master events)
+}
+```
+
+**`client.go` -- Update `eventToInfo`** (line 220):
+
+Add extraction of recurrence fields from Google API response:
+
+```go
+func eventToInfo(e *gcalendar.Event) EventInfo {
+	info := EventInfo{
+		// ... existing fields ...
+	}
+	// Recurrence metadata
+	if len(e.Recurrence) > 0 {
+		info.IsRecurring = true
+		info.Recurrence = e.Recurrence
+	}
+	if e.RecurringEventId != "" {
+		info.IsRecurring = true
+		info.RecurringEventID = e.RecurringEventId
+	}
+	return info
+}
+```
+
+**`client.go` -- Update `CreateEvent` signature**:
+
+Add `recurrence []string` parameter. Set `event.Recurrence` before insert.
+
+```go
+func CreateEvent(ctx context.Context, ts oauth2.TokenSource, calendarID string,
+	title, description, location string, start, end time.Time,
+	allDay bool, timezone string, recurrence []string) (*EventInfo, error)
+```
+
+**`client.go` -- New `GetEvent` function**:
+
+Needed for this-and-future operations to fetch the master event:
+
+```go
+func GetEvent(ctx context.Context, ts oauth2.TokenSource, calendarID, eventID string) (*EventInfo, error)
+```
+
+**`client.go` -- New `masterEventID` helper**:
+
+Derive master event ID from an instance ID:
+
+```go
+func masterEventID(eventID string) string {
+	// Instance IDs: "{masterId}_{YYYYMMDDTHHMMSSZ}" or "{masterId}_{YYYYMMDD}"
+	// Master IDs use base32hex: [a-v0-9]{5,1024}
+	if idx := strings.LastIndex(eventID, "_"); idx > 0 {
+		suffix := eventID[idx+1:]
+		// Check if suffix looks like a timestamp (8+ digits/T/Z chars)
+		if len(suffix) >= 8 && (suffix[0] >= '0' && suffix[0] <= '9') {
+			return eventID[:idx]
+		}
+	}
+	return eventID // already a master ID
+}
+```
+
+**`client.go` -- Add 400 error handling in `mapAPIError`** (line 276):
+
+```go
+case 400:
+	return fmt.Errorf("Invalid request. If creating a recurring event, check the recurrence rule format (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU).")
+```
+
+**`client.go` -- Update `FindEventByTitle` to deduplicate recurring instances**:
+
+When multiple results share the same `RecurringEventId`, group them and return only the first instance (with the master ID available via `RecurringEventID` field).
+
+#### Phase 2: Schema, Description, and ParseArgs updates
+
+**`calendar.go` -- Update `Schema()`** (line 33):
+
+Add two new properties:
+
+```go
+"recurrence": map[string]any{
+	"type": "string",
+	"description": "iCal RRULE string for recurring events (optional). " +
+		"Examples: RRULE:FREQ=DAILY, RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR, " +
+		"RRULE:FREQ=MONTHLY;BYMONTHDAY=1, RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=9, " +
+		"RRULE:FREQ=WEEKLY;BYDAY=TU;COUNT=10, RRULE:FREQ=DAILY;UNTIL=20261231T235959Z. " +
+		"Must start with RRULE: prefix. Used only with create command.",
+},
+"scope": map[string]any{
+	"type": "string",
+	"enum": []string{"single", "all", "this_and_future"},
+	"description": "Scope for update/delete on recurring events. " +
+		"'single': modify only this instance (default). " +
+		"'all': modify the entire recurring series. " +
+		"'this_and_future': modify this instance and all future instances. " +
+		"When the user's intent is ambiguous for a recurring event, ask them to clarify. " +
+		"Ignored for non-recurring events.",
+},
+```
+
+**`calendar.go` -- Update `Description()`** (line 29):
+
+```go
+func (t *CalendarTool) Description() string {
+	return "Manage Google Calendar events for this topic. Supports one-time and recurring events. " +
+		"Use the recurrence parameter with create to set up repeating events (pass an iCal RRULE string). " +
+		"For recurring events, use the scope parameter with update/delete to choose: " +
+		"'single' (this instance only), 'all' (entire series), or 'this_and_future' (this and all later instances). " +
+		"When a user's intent about recurring event scope is ambiguous, ask them to clarify. " +
+		"Event IDs from list results can be used directly -- the tool handles instance-vs-series resolution internally."
+}
+```
+
+**`calendar.go` -- Update `ParseArgs`**:
+
+- **create**: Add `--recurrence=` flag. Use `strings.SplitN(p, "=", 2)` for all flag parsing to handle `=` chars in RRULE values.
+- **update**: Add `--scope=` and `--recurrence=` flags.
+- **delete**: Accept optional `--scope=` flag after event_id.
+
+```go
+// In create ParseArgs, after existing positional args:
+for _, p := range parts[4:] {
+	if strings.HasPrefix(p, "--recurrence=") {
+		kv := strings.SplitN(p, "=", 2)
+		if len(kv) == 2 {
+			result["recurrence"] = kv[1]
+		}
+	} else if strings.HasPrefix(p, "--") {
+		// skip unknown flags
+	} else {
+		// accumulate description words
+	}
+}
+```
+
+#### Phase 3: Execute handler updates
+
+**`calendar.go` -- Update `execCreate`**:
+
+Extract `recurrence` from input, validate basic format, pass to `CreateEvent`:
+
+```go
+var recurrence []string
+if rec, ok := input["recurrence"].(string); ok && rec != "" {
+	if err := validateRRULE(rec); err != nil {
+		return "", err
+	}
+	recurrence = []string{rec}
+}
+
+event, err := CreateEvent(ctx, ts, cal.CalendarID, title, description, location,
+	startTime, endTime, allDay, cal.Timezone, recurrence)
+```
+
+Add recurrence info to create confirmation output:
+
+```go
+if len(recurrence) > 0 {
+	sb.WriteString(fmt.Sprintf("Recurrence: %s\n", recurrence[0]))
+}
+```
+
+**`calendar.go` -- Update `execUpdate`**:
+
+Add scope-aware routing:
+
+```go
+func (t *CalendarTool) execUpdate(ctx context.Context, ts oauth2.TokenSource,
+	cal *TopicCalendar, input map[string]any) (string, error) {
+
+	eventID := resolveEventID(input) // existing ID/title resolution
+	scope := extractScope(input)     // "single" (default), "all", "this_and_future"
+
+	switch scope {
+	case "all":
+		masterID := masterEventID(eventID)
+		return t.updateAllInstances(ctx, ts, cal, masterID, input)
+	case "this_and_future":
+		return t.updateThisAndFuture(ctx, ts, cal, eventID, input)
+	default: // "single"
+		return t.updateSingleInstance(ctx, ts, cal, eventID, input)
+	}
+}
+```
+
+- `updateSingleInstance`: Existing `UpdateEvent` logic (Patch with instance ID).
+- `updateAllInstances`: Patch with master ID. Also handle recurrence changes.
+- `updateThisAndFuture`: (1) Fetch master event, (2) save original RRULE, (3) trim master with UNTIL before target instance, (4) create new series from target instance with changes, (5) rollback master if create fails.
+
+**`calendar.go` -- Update `execDelete`**:
+
+Add scope-aware routing:
+
+```go
+func (t *CalendarTool) execDelete(ctx context.Context, ts oauth2.TokenSource,
+	cal *TopicCalendar, input map[string]any) (string, error) {
+
+	eventID := resolveEventID(input)
+	scope := extractScope(input)
+
+	switch scope {
+	case "all":
+		masterID := masterEventID(eventID)
+		return t.deleteAllInstances(ctx, ts, cal, masterID)
+	case "this_and_future":
+		return t.deleteThisAndFuture(ctx, ts, cal, eventID)
+	default: // "single"
+		return t.deleteSingleInstance(ctx, ts, cal, eventID)
+	}
+}
+```
+
+- `deleteSingleInstance`: Existing `DeleteEvent` logic.
+- `deleteAllInstances`: Delete with master ID.
+- `deleteThisAndFuture`: Fetch master, trim RRULE with UNTIL before target instance's `OriginalStartTime`.
+
+**`calendar.go` -- Update `execList`**:
+
+Add `(recurring)` marker and recurrence info to output:
+
+```go
+if e.IsRecurring {
+	sb.WriteString(" (recurring)")
+}
+```
+
+#### Phase 4: RRULE validation helper
+
+Simple validation -- no external library needed:
+
+```go
+func validateRRULE(rule string) error {
+	if !strings.HasPrefix(rule, "RRULE:") {
+		return fmt.Errorf("recurrence rule must start with RRULE: prefix (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU)")
+	}
+	parts := strings.TrimPrefix(rule, "RRULE:")
+	if !strings.Contains(parts, "FREQ=") {
+		return fmt.Errorf("recurrence rule must contain FREQ= (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU)")
+	}
+	freqValues := []string{"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}
+	hasValidFreq := false
+	for _, kv := range strings.Split(parts, ";") {
+		if strings.HasPrefix(kv, "FREQ=") {
+			freq := strings.TrimPrefix(kv, "FREQ=")
+			for _, valid := range freqValues {
+				if freq == valid {
+					hasValidFreq = true
+				}
+			}
+		}
+	}
+	if !hasValidFreq {
+		return fmt.Errorf("FREQ must be one of: DAILY, WEEKLY, MONTHLY, YEARLY")
+	}
+	return nil
+}
+```
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `tools/calendar/client.go` | `EventInfo` struct (3 new fields), `eventToInfo`, `CreateEvent` signature, new `GetEvent`, `masterEventID` helper, `mapAPIError` (400 case), `FindEventByTitle` dedup |
+| `tools/calendar/calendar.go` | `Schema()` (2 new properties), `Description()`, `ParseArgs` (recurrence/scope flags), `execCreate` (recurrence param), `execUpdate` (scope routing + 3 sub-handlers), `execDelete` (scope routing + 3 sub-handlers), `execList` (recurring marker), `validateRRULE` helper |
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] **Create**: `/calendar create` and LLM tool call accept `recurrence` parameter with RRULE string
+- [x] **Create**: Recurring event is created as a single Google Calendar recurring event (not multiple individual events)
+- [x] **Create**: Confirmation output includes the recurrence rule
+- [x] **Update single**: Updating with `scope=single` (or no scope) modifies only the target instance
+- [x] **Update all**: Updating with `scope=all` modifies the entire recurring series via master ID
+- [x] **Update this-and-future**: Updating with `scope=this_and_future` trims the original series and creates a new one
+- [x] **Update recurrence**: Can add/change/remove recurrence rule on an existing event
+- [x] **Delete single**: Deleting with `scope=single` (or no scope) removes only the target instance
+- [x] **Delete all**: Deleting with `scope=all` removes the entire recurring series
+- [x] **Delete this-and-future**: Deleting with `scope=this_and_future` trims the series at the target instance
+- [x] **List**: Recurring events display `(recurring)` marker in list output
+- [x] **List**: No breaking changes to existing list behavior
+- [x] **Schema**: Tool schema includes `recurrence` and `scope` properties with clear descriptions
+- [x] **Description**: Tool description explains recurrence support and scope semantics
+- [x] **Validation**: Invalid RRULE strings return a helpful error message
+- [x] **Backward compat**: Non-recurring event operations are unaffected by the changes
+
+### Error Handling
+
+- [x] **Invalid RRULE**: Returns user-friendly error (not raw Google API error)
+- [x] **Scope on non-recurring event**: Scope is silently ignored
+- [x] **This-and-future rollback**: If new series creation fails, master RRULE is restored
+- [x] **Google API 400**: Mapped to helpful error message about recurrence format
+
+## Dependencies & Risks
+
+**Dependencies**: None -- only uses existing Google Calendar API v3 library already in `go.mod`.
+
+**Risks**:
+- **This-and-future is not atomic**: Two API calls can partially fail. Mitigated by rollback strategy.
+- **Instance ID parsing is heuristic**: The `masterEventID` helper uses format-based detection. If Google changes ID format, this could break. Mitigated by the pattern being stable since 2011.
+- **LLM RRULE accuracy**: The LLM may generate incorrect RRULE strings for complex patterns. Mitigated by basic validation + Google API validation + examples in schema description.
+
+## References & Research
+
+### Internal References
+
+- Calendar tool: `tools/calendar/calendar.go` (Schema, Execute, ParseArgs)
+- Calendar client: `tools/calendar/client.go` (EventInfo, CreateEvent, UpdateEvent, DeleteEvent)
+- Tool interface: `tools/registry.go` (Name, Description, Schema, ParseArgs, Execute, AdminOnly)
+- Past solution: `docs/solutions/logic-errors/calendar-list-missing-event-details.md` (render pattern for new fields)
+- Original calendar plan: `docs/plans/2026-02-26-feat-google-calendar-integration-plan.md`
+
+### External References
+
+- [Google Calendar API Recurring Events Guide](https://developers.google.com/workspace/calendar/api/guides/recurringevents)
+- [Google Calendar API Events Resource](https://developers.google.com/workspace/calendar/api/v3/reference/events)
+- [iCal RRULE RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10)
+- Go client: `google.golang.org/api/calendar/v3` (`Event.Recurrence []string`, `Event.RecurringEventId`)

--- a/tools/calendar/calendar.go
+++ b/tools/calendar/calendar.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/esnunes/bobot/auth"
 	"golang.org/x/oauth2"
+	gcalendar "google.golang.org/api/calendar/v3"
 )
 
 type CalendarTool struct {
@@ -27,7 +28,12 @@ func (t *CalendarTool) Name() string    { return "calendar" }
 func (t *CalendarTool) AdminOnly() bool { return false }
 
 func (t *CalendarTool) Description() string {
-	return "Manage Google Calendar events for this topic. List upcoming events, create new events, update existing events, and delete events. The calendar must be connected by the topic owner in settings first."
+	return "Manage Google Calendar events for this topic. Supports one-time and recurring events. " +
+		"Use the recurrence parameter with create to set up repeating events (pass an iCal RRULE string). " +
+		"For recurring events, use the scope parameter with update/delete to choose: " +
+		"'single' (this instance only), 'all' (entire series), or 'this_and_future' (this and all later instances). " +
+		"When a user's intent about recurring event scope is ambiguous, ask them to clarify. " +
+		"Event IDs from list results can be used directly -- the tool handles instance-vs-series resolution internally."
 }
 
 func (t *CalendarTool) Schema() any {
@@ -71,6 +77,19 @@ func (t *CalendarTool) Schema() any {
 				"type":        "string",
 				"description": "End of date range for list (default: 7 days from start). Format: YYYY-MM-DD",
 			},
+			"recurrence": map[string]any{
+				"type": "string",
+				"description": "iCal RRULE string for recurring events (optional). " +
+					"Examples: RRULE:FREQ=DAILY, RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR, " +
+					"RRULE:FREQ=MONTHLY;BYMONTHDAY=1, RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=9, " +
+					"RRULE:FREQ=WEEKLY;BYDAY=TU;COUNT=10, RRULE:FREQ=DAILY;UNTIL=20261231T235959Z. " +
+					"Must start with RRULE: prefix. Used only with create command.",
+			},
+			"scope": map[string]any{
+				"type":        "string",
+				"enum":        []string{"single", "all", "this_and_future"},
+				"description": "Scope for update/delete on recurring events. 'single': modify only this instance (default). 'all': modify the entire recurring series. 'this_and_future': modify this instance and all future instances. When the user's intent is ambiguous for a recurring event, ask them to clarify. Ignored for non-recurring events.",
+			},
 		},
 		"required": []string{"command"},
 	}
@@ -97,39 +116,68 @@ func (t *CalendarTool) ParseArgs(raw string) (map[string]any, error) {
 
 	case "create":
 		if len(parts) < 4 {
-			return nil, fmt.Errorf("usage: /calendar create <title> <start> <end> [description]")
+			return nil, fmt.Errorf("usage: /calendar create <title> <start> <end> [--recurrence=RRULE:...] [description]")
 		}
 		result["title"] = parts[1]
 		result["start"] = parts[2]
 		result["end"] = parts[3]
-		if len(parts) > 4 {
-			result["description"] = strings.Join(parts[4:], " ")
+		var descWords []string
+		for _, p := range parts[4:] {
+			if strings.HasPrefix(p, "--recurrence=") {
+				kv := strings.SplitN(p, "=", 2)
+				if len(kv) == 2 {
+					result["recurrence"] = kv[1]
+				}
+			} else if !strings.HasPrefix(p, "--") {
+				descWords = append(descWords, p)
+			}
+		}
+		if len(descWords) > 0 {
+			result["description"] = strings.Join(descWords, " ")
 		}
 		return result, nil
 
 	case "update":
 		if len(parts) < 2 {
-			return nil, fmt.Errorf("usage: /calendar update <event_id> [--title=...] [--start=...] [--end=...]")
+			return nil, fmt.Errorf("usage: /calendar update <event_id> [--title=...] [--start=...] [--end=...] [--scope=...]")
 		}
 		result["event_id"] = parts[1]
 		for _, p := range parts[2:] {
-			if strings.HasPrefix(p, "--title=") {
-				result["title"] = strings.TrimPrefix(p, "--title=")
-			} else if strings.HasPrefix(p, "--start=") {
-				result["start"] = strings.TrimPrefix(p, "--start=")
-			} else if strings.HasPrefix(p, "--end=") {
-				result["end"] = strings.TrimPrefix(p, "--end=")
-			} else if strings.HasPrefix(p, "--description=") {
-				result["description"] = strings.TrimPrefix(p, "--description=")
+			kv := strings.SplitN(p, "=", 2)
+			if len(kv) != 2 || !strings.HasPrefix(kv[0], "--") {
+				continue
+			}
+			key := strings.TrimPrefix(kv[0], "--")
+			switch key {
+			case "title":
+				result["title"] = kv[1]
+			case "start":
+				result["start"] = kv[1]
+			case "end":
+				result["end"] = kv[1]
+			case "description":
+				result["description"] = kv[1]
+			case "recurrence":
+				result["recurrence"] = kv[1]
+			case "scope":
+				result["scope"] = kv[1]
 			}
 		}
 		return result, nil
 
 	case "delete":
 		if len(parts) < 2 {
-			return nil, fmt.Errorf("usage: /calendar delete <event_id>")
+			return nil, fmt.Errorf("usage: /calendar delete <event_id> [--scope=single|all|this_and_future]")
 		}
 		result["event_id"] = parts[1]
+		for _, p := range parts[2:] {
+			if strings.HasPrefix(p, "--scope=") {
+				kv := strings.SplitN(p, "=", 2)
+				if len(kv) == 2 {
+					result["scope"] = kv[1]
+				}
+			}
+		}
 		return result, nil
 
 	default:
@@ -220,6 +268,9 @@ func (t *CalendarTool) execList(ctx context.Context, ts oauth2.TokenSource, cal 
 			end := formatEventTime(e.End)
 			sb.WriteString(fmt.Sprintf("- **%s** (%s - %s)", e.Title, start, end))
 		}
+		if e.IsRecurring {
+			sb.WriteString(" (recurring)")
+		}
 		sb.WriteString(fmt.Sprintf(" [ID: %s]\n", e.ID))
 		if e.Location != "" {
 			sb.WriteString(fmt.Sprintf("  Location: %s\n", e.Location))
@@ -271,7 +322,15 @@ func (t *CalendarTool) execCreate(ctx context.Context, ts oauth2.TokenSource, ca
 		endTime = startTime.Add(time.Hour) // Default 1 hour
 	}
 
-	event, err := CreateEvent(ctx, ts, cal.CalendarID, title, description, location, startTime, endTime, allDay, cal.Timezone)
+	var recurrence []string
+	if rec, ok := input["recurrence"].(string); ok && rec != "" {
+		if err := validateRRULE(rec); err != nil {
+			return "", err
+		}
+		recurrence = []string{rec}
+	}
+
+	event, err := CreateEvent(ctx, ts, cal.CalendarID, title, description, location, startTime, endTime, allDay, cal.Timezone, recurrence)
 	if err != nil {
 		return "", err
 	}
@@ -286,37 +345,307 @@ func (t *CalendarTool) execCreate(ctx context.Context, ts oauth2.TokenSource, ca
 	if event.Location != "" {
 		sb.WriteString(fmt.Sprintf("Location: %s\n", event.Location))
 	}
+	if len(recurrence) > 0 {
+		sb.WriteString(fmt.Sprintf("Recurrence: %s\n", recurrence[0]))
+	}
 	sb.WriteString(fmt.Sprintf("ID: %s", event.ID))
 
 	return sb.String(), nil
 }
 
 func (t *CalendarTool) execUpdate(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
-	eventID, _ := input["event_id"].(string)
+	eventID, err := t.resolveEventID(ctx, ts, cal, input)
+	if err != nil {
+		return "", err
+	}
 	if eventID == "" {
-		// Try to find by title
-		title, _ := input["title"].(string)
-		if title == "" {
-			return "", fmt.Errorf("event_id or title is required for update")
-		}
-		matches, err := FindEventByTitle(ctx, ts, cal.CalendarID, title)
+		// resolveEventID returned a user-facing message via error=nil
+		return "", fmt.Errorf("event_id or title is required for update")
+	}
+
+	scope := extractScope(input)
+
+	switch scope {
+	case "all":
+		return t.updateAllInstances(ctx, ts, cal, eventID, input)
+	case "this_and_future":
+		return t.updateThisAndFuture(ctx, ts, cal, eventID, input)
+	default: // "single"
+		return t.updateSingleInstance(ctx, ts, cal, eventID, input)
+	}
+}
+
+func (t *CalendarTool) updateSingleInstance(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string, input map[string]any) (string, error) {
+	updates := buildUpdates(input)
+
+	event, err := UpdateEvent(ctx, ts, cal.CalendarID, eventID, updates, cal.Timezone)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Event updated: **%s** (%s - %s) [ID: %s]",
+		event.Title, formatEventTime(event.Start), formatEventTime(event.End), event.ID), nil
+}
+
+func (t *CalendarTool) updateAllInstances(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string, input map[string]any) (string, error) {
+	masterID := masterEventID(eventID)
+	updates := buildUpdates(input)
+
+	// Handle recurrence changes on the master event
+	if rec, ok := input["recurrence"].(string); ok {
+		updates["recurrence"] = rec
+	}
+
+	// For recurrence changes, we need to use the raw event API
+	if _, hasRec := updates["recurrence"]; hasRec {
+		raw, err := GetRawEvent(ctx, ts, cal.CalendarID, masterID)
 		if err != nil {
 			return "", err
 		}
-		if len(matches) == 0 {
-			return fmt.Sprintf("No event found matching '%s'.", title), nil
+
+		rec := updates["recurrence"].(string)
+		if rec == "" {
+			// Remove recurrence
+			raw.Recurrence = nil
+		} else {
+			raw.Recurrence = []string{rec}
 		}
-		if len(matches) > 1 {
-			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Multiple events match '%s'. Please specify event_id:\n", title))
-			for _, m := range matches {
-				sb.WriteString(fmt.Sprintf("- %s (%s) [ID: %s]\n", m.Title, formatEventTime(m.Start), m.ID))
-			}
-			return sb.String(), nil
+		delete(updates, "recurrence")
+
+		// Apply other updates to raw event
+		applyUpdatesToRaw(raw, updates, cal.Timezone)
+
+		updated, err := UpdateRawEvent(ctx, ts, cal.CalendarID, masterID, raw)
+		if err != nil {
+			return "", err
 		}
-		eventID = matches[0].ID
+
+		info := eventToInfo(updated)
+		return fmt.Sprintf("All instances updated: **%s** [ID: %s]", info.Title, info.ID), nil
 	}
 
+	event, err := UpdateEvent(ctx, ts, cal.CalendarID, masterID, updates, cal.Timezone)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("All instances updated: **%s** [ID: %s]", event.Title, event.ID), nil
+}
+
+func (t *CalendarTool) updateThisAndFuture(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string, input map[string]any) (string, error) {
+	// Get the instance to find its start time
+	instance, err := GetRawEvent(ctx, ts, cal.CalendarID, eventID)
+	if err != nil {
+		return "", fmt.Errorf("fetching event instance: %w", err)
+	}
+
+	masterID := masterEventID(eventID)
+	if masterID == eventID && instance.RecurringEventId == "" {
+		// Not a recurring event instance, fall back to single update
+		return t.updateSingleInstance(ctx, ts, cal, eventID, input)
+	}
+	if instance.RecurringEventId != "" {
+		masterID = instance.RecurringEventId
+	}
+
+	// Get the master event
+	master, err := GetRawEvent(ctx, ts, cal.CalendarID, masterID)
+	if err != nil {
+		return "", fmt.Errorf("fetching master event: %w", err)
+	}
+
+	// Save original recurrence for rollback
+	originalRecurrence := make([]string, len(master.Recurrence))
+	copy(originalRecurrence, master.Recurrence)
+
+	// Determine the UNTIL timestamp (1 second before this instance's start)
+	untilTime := instanceStartTime(instance)
+	if untilTime.IsZero() {
+		return "", fmt.Errorf("could not determine instance start time")
+	}
+	until := untilTime.Add(-time.Second).UTC().Format("20060102T150405Z")
+
+	// Step 1: Trim master RRULE with UNTIL
+	trimmedRecurrence := trimRecurrenceUntil(master.Recurrence, until)
+	master.Recurrence = trimmedRecurrence
+	_, err = UpdateRawEvent(ctx, ts, cal.CalendarID, masterID, master)
+	if err != nil {
+		return "", fmt.Errorf("trimming recurring series: %w", err)
+	}
+
+	// Step 2: Create new series from this instance with changes
+	newStart := untilTime
+	newEnd := instanceEndTime(instance)
+	if newEnd.IsZero() {
+		newEnd = newStart.Add(time.Hour)
+	}
+
+	title := master.Summary
+	description := master.Description
+	location := master.Location
+	newRecurrence := originalRecurrence
+
+	// Apply user updates
+	if t, ok := input["title"].(string); ok && t != "" {
+		title = t
+	}
+	if d, ok := input["description"].(string); ok {
+		description = d
+	}
+	if l, ok := input["location"].(string); ok {
+		location = l
+	}
+	if startStr, ok := input["start"].(string); ok && startStr != "" {
+		parsed, err := parseFlexibleTime(startStr, cal.Timezone)
+		if err == nil {
+			newStart = parsed
+		}
+	}
+	if endStr, ok := input["end"].(string); ok && endStr != "" {
+		parsed, err := parseFlexibleTime(endStr, cal.Timezone)
+		if err == nil {
+			newEnd = parsed
+		}
+	}
+	if rec, ok := input["recurrence"].(string); ok && rec != "" {
+		newRecurrence = []string{rec}
+	}
+
+	// Remove any UNTIL/COUNT from new recurrence to let it continue
+	allDay := instance.Start != nil && instance.Start.Date != ""
+
+	created, err := CreateEvent(ctx, ts, cal.CalendarID, title, description, location, newStart, newEnd, allDay, cal.Timezone, newRecurrence)
+	if err != nil {
+		// Rollback: restore original master recurrence
+		master.Recurrence = originalRecurrence
+		_, rollbackErr := UpdateRawEvent(ctx, ts, cal.CalendarID, masterID, master)
+		if rollbackErr != nil {
+			return "", fmt.Errorf("failed to create new series (%w) and rollback also failed (%w)", err, rollbackErr)
+		}
+		return "", fmt.Errorf("failed to create new series (original series restored): %w", err)
+	}
+
+	return fmt.Sprintf("Updated this and future instances. Original series trimmed, new series created: **%s** [ID: %s]",
+		created.Title, created.ID), nil
+}
+
+func (t *CalendarTool) execDelete(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
+	eventID, err := t.resolveEventID(ctx, ts, cal, input)
+	if err != nil {
+		return "", err
+	}
+	if eventID == "" {
+		return "", fmt.Errorf("event_id or title is required for delete")
+	}
+
+	scope := extractScope(input)
+
+	switch scope {
+	case "all":
+		return t.deleteAllInstances(ctx, ts, cal, eventID)
+	case "this_and_future":
+		return t.deleteThisAndFuture(ctx, ts, cal, eventID)
+	default: // "single"
+		return t.deleteSingleInstance(ctx, ts, cal, eventID)
+	}
+}
+
+func (t *CalendarTool) deleteSingleInstance(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string) (string, error) {
+	if err := DeleteEvent(ctx, ts, cal.CalendarID, eventID); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Event deleted successfully. [ID: %s]", eventID), nil
+}
+
+func (t *CalendarTool) deleteAllInstances(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string) (string, error) {
+	masterID := masterEventID(eventID)
+	if err := DeleteEvent(ctx, ts, cal.CalendarID, masterID); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("All instances of recurring event deleted. [ID: %s]", masterID), nil
+}
+
+func (t *CalendarTool) deleteThisAndFuture(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string) (string, error) {
+	// Get the instance to find its start time
+	instance, err := GetRawEvent(ctx, ts, cal.CalendarID, eventID)
+	if err != nil {
+		return "", fmt.Errorf("fetching event instance: %w", err)
+	}
+
+	masterID := masterEventID(eventID)
+	if masterID == eventID && instance.RecurringEventId == "" {
+		// Not a recurring event instance, just delete the single event
+		return t.deleteSingleInstance(ctx, ts, cal, eventID)
+	}
+	if instance.RecurringEventId != "" {
+		masterID = instance.RecurringEventId
+	}
+
+	// Get the master event
+	master, err := GetRawEvent(ctx, ts, cal.CalendarID, masterID)
+	if err != nil {
+		return "", fmt.Errorf("fetching master event: %w", err)
+	}
+
+	// Trim the RRULE with UNTIL set before this instance
+	untilTime := instanceStartTime(instance)
+	if untilTime.IsZero() {
+		return "", fmt.Errorf("could not determine instance start time")
+	}
+	until := untilTime.Add(-time.Second).UTC().Format("20060102T150405Z")
+
+	master.Recurrence = trimRecurrenceUntil(master.Recurrence, until)
+	_, err = UpdateRawEvent(ctx, ts, cal.CalendarID, masterID, master)
+	if err != nil {
+		return "", fmt.Errorf("trimming recurring series: %w", err)
+	}
+
+	return fmt.Sprintf("This and all future instances deleted. Series trimmed at %s. [ID: %s]",
+		untilTime.Format("2006-01-02"), masterID), nil
+}
+
+// resolveEventID resolves an event ID from input, either directly or by title search.
+// Returns the event ID and a user-facing message if multiple matches are found.
+func (t *CalendarTool) resolveEventID(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
+	eventID, _ := input["event_id"].(string)
+	if eventID != "" {
+		return eventID, nil
+	}
+
+	title, _ := input["title"].(string)
+	if title == "" {
+		return "", nil
+	}
+
+	matches, err := FindEventByTitle(ctx, ts, cal.CalendarID, title)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no event found matching '%s'", title)
+	}
+	if len(matches) > 1 {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("Multiple events match '%s'. Please specify event_id:\n", title))
+		for _, m := range matches {
+			sb.WriteString(fmt.Sprintf("- %s (%s) [ID: %s]\n", m.Title, formatEventTime(m.Start), m.ID))
+		}
+		return "", fmt.Errorf("%s", sb.String())
+	}
+	return matches[0].ID, nil
+}
+
+func extractScope(input map[string]any) string {
+	scope, _ := input["scope"].(string)
+	switch scope {
+	case "all", "this_and_future":
+		return scope
+	default:
+		return "single"
+	}
+}
+
+func buildUpdates(input map[string]any) map[string]any {
 	updates := make(map[string]any)
 	if title, ok := input["title"].(string); ok {
 		updates["title"] = title
@@ -333,47 +662,134 @@ func (t *CalendarTool) execUpdate(ctx context.Context, ts oauth2.TokenSource, ca
 	if loc, ok := input["location"].(string); ok {
 		updates["location"] = loc
 	}
-
-	event, err := UpdateEvent(ctx, ts, cal.CalendarID, eventID, updates, cal.Timezone)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("Event updated: **%s** (%s - %s) [ID: %s]",
-		event.Title, formatEventTime(event.Start), formatEventTime(event.End), event.ID), nil
+	return updates
 }
 
-func (t *CalendarTool) execDelete(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
-	eventID, _ := input["event_id"].(string)
-	if eventID == "" {
-		// Try to find by title
-		title, _ := input["title"].(string)
-		if title == "" {
-			return "", fmt.Errorf("event_id or title is required for delete")
-		}
-		matches, err := FindEventByTitle(ctx, ts, cal.CalendarID, title)
-		if err != nil {
-			return "", err
-		}
-		if len(matches) == 0 {
-			return fmt.Sprintf("No event found matching '%s'.", title), nil
-		}
-		if len(matches) > 1 {
-			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Multiple events match '%s'. Please specify event_id:\n", title))
-			for _, m := range matches {
-				sb.WriteString(fmt.Sprintf("- %s (%s) [ID: %s]\n", m.Title, formatEventTime(m.Start), m.ID))
+func applyUpdatesToRaw(raw *gcalendar.Event, updates map[string]any, timezone string) {
+	if title, ok := updates["title"].(string); ok && title != "" {
+		raw.Summary = title
+	}
+	if desc, ok := updates["description"].(string); ok {
+		raw.Description = desc
+	}
+	if loc, ok := updates["location"].(string); ok {
+		raw.Location = loc
+	}
+	if startStr, ok := updates["start"].(string); ok && startStr != "" {
+		t, err := parseFlexibleTime(startStr, timezone)
+		if err == nil {
+			raw.Start = &gcalendar.EventDateTime{
+				DateTime: t.Format(time.RFC3339),
+				TimeZone: timezone,
 			}
-			return sb.String(), nil
 		}
-		eventID = matches[0].ID
 	}
-
-	if err := DeleteEvent(ctx, ts, cal.CalendarID, eventID); err != nil {
-		return "", err
+	if endStr, ok := updates["end"].(string); ok && endStr != "" {
+		t, err := parseFlexibleTime(endStr, timezone)
+		if err == nil {
+			raw.End = &gcalendar.EventDateTime{
+				DateTime: t.Format(time.RFC3339),
+				TimeZone: timezone,
+			}
+		}
 	}
+}
 
-	return fmt.Sprintf("Event deleted successfully. [ID: %s]", eventID), nil
+func validateRRULE(rule string) error {
+	if !strings.HasPrefix(rule, "RRULE:") {
+		return fmt.Errorf("recurrence rule must start with RRULE: prefix (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU)")
+	}
+	body := strings.TrimPrefix(rule, "RRULE:")
+	if !strings.Contains(body, "FREQ=") {
+		return fmt.Errorf("recurrence rule must contain FREQ= (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU)")
+	}
+	freqValues := map[string]bool{"DAILY": true, "WEEKLY": true, "MONTHLY": true, "YEARLY": true}
+	for _, kv := range strings.Split(body, ";") {
+		if strings.HasPrefix(kv, "FREQ=") {
+			freq := strings.TrimPrefix(kv, "FREQ=")
+			if !freqValues[freq] {
+				return fmt.Errorf("FREQ must be one of: DAILY, WEEKLY, MONTHLY, YEARLY")
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("recurrence rule must contain a valid FREQ value")
+}
+
+// instanceStartTime extracts the start time from a Google Calendar event instance.
+func instanceStartTime(e *gcalendar.Event) time.Time {
+	if e.OriginalStartTime != nil {
+		if e.OriginalStartTime.DateTime != "" {
+			if t, err := time.Parse(time.RFC3339, e.OriginalStartTime.DateTime); err == nil {
+				return t
+			}
+		}
+		if e.OriginalStartTime.Date != "" {
+			if t, err := time.Parse("2006-01-02", e.OriginalStartTime.Date); err == nil {
+				return t
+			}
+		}
+	}
+	if e.Start != nil {
+		if e.Start.DateTime != "" {
+			if t, err := time.Parse(time.RFC3339, e.Start.DateTime); err == nil {
+				return t
+			}
+		}
+		if e.Start.Date != "" {
+			if t, err := time.Parse("2006-01-02", e.Start.Date); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}
+
+// instanceEndTime extracts the end time from a Google Calendar event instance.
+func instanceEndTime(e *gcalendar.Event) time.Time {
+	if e.End != nil {
+		if e.End.DateTime != "" {
+			if t, err := time.Parse(time.RFC3339, e.End.DateTime); err == nil {
+				return t
+			}
+		}
+		if e.End.Date != "" {
+			if t, err := time.Parse("2006-01-02", e.End.Date); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}
+
+// trimRecurrenceUntil modifies RRULE strings to add or replace an UNTIL clause.
+func trimRecurrenceUntil(recurrence []string, until string) []string {
+	var result []string
+	for _, rule := range recurrence {
+		if !strings.HasPrefix(rule, "RRULE:") {
+			result = append(result, rule)
+			continue
+		}
+		body := strings.TrimPrefix(rule, "RRULE:")
+		var parts []string
+		hasUntil := false
+		for _, part := range strings.Split(body, ";") {
+			if strings.HasPrefix(part, "UNTIL=") {
+				parts = append(parts, "UNTIL="+until)
+				hasUntil = true
+			} else if strings.HasPrefix(part, "COUNT=") {
+				// Remove COUNT when adding UNTIL (they are mutually exclusive)
+				continue
+			} else {
+				parts = append(parts, part)
+			}
+		}
+		if !hasUntil {
+			parts = append(parts, "UNTIL="+until)
+		}
+		result = append(result, "RRULE:"+strings.Join(parts, ";"))
+	}
+	return result
 }
 
 func formatEventTime(s string) string {

--- a/tools/calendar/calendar.go
+++ b/tools/calendar/calendar.go
@@ -83,7 +83,8 @@ func (t *CalendarTool) Schema() any {
 					"Examples: RRULE:FREQ=DAILY, RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR, " +
 					"RRULE:FREQ=MONTHLY;BYMONTHDAY=1, RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=9, " +
 					"RRULE:FREQ=WEEKLY;BYDAY=TU;COUNT=10, RRULE:FREQ=DAILY;UNTIL=20261231T235959Z. " +
-					"Must start with RRULE: prefix. Used only with create command.",
+					"Must start with RRULE: prefix. Used with create to set up recurring events, " +
+					"or with update (scope='all' or 'this_and_future') to change the recurrence rule.",
 			},
 			"scope": map[string]any{
 				"type":        "string",
@@ -128,6 +129,11 @@ func (t *CalendarTool) ParseArgs(raw string) (map[string]any, error) {
 				if len(kv) == 2 {
 					result["recurrence"] = kv[1]
 				}
+			} else if strings.HasPrefix(p, "--location=") {
+				kv := strings.SplitN(p, "=", 2)
+				if len(kv) == 2 {
+					result["location"] = kv[1]
+				}
 			} else if !strings.HasPrefix(p, "--") {
 				descWords = append(descWords, p)
 			}
@@ -157,6 +163,8 @@ func (t *CalendarTool) ParseArgs(raw string) (map[string]any, error) {
 				result["end"] = kv[1]
 			case "description":
 				result["description"] = kv[1]
+			case "location":
+				result["location"] = kv[1]
 			case "recurrence":
 				result["recurrence"] = kv[1]
 			case "scope":
@@ -354,12 +362,14 @@ func (t *CalendarTool) execCreate(ctx context.Context, ts oauth2.TokenSource, ca
 }
 
 func (t *CalendarTool) execUpdate(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
-	eventID, err := t.resolveEventID(ctx, ts, cal, input)
+	eventID, msg, err := t.resolveEventID(ctx, ts, cal, input)
 	if err != nil {
 		return "", err
 	}
+	if msg != "" {
+		return msg, nil
+	}
 	if eventID == "" {
-		// resolveEventID returned a user-facing message via error=nil
 		return "", fmt.Errorf("event_id or title is required for update")
 	}
 
@@ -406,6 +416,11 @@ func (t *CalendarTool) updateAllInstances(ctx context.Context, ts oauth2.TokenSo
 
 	// Handle recurrence changes on the master event
 	if rec, ok := input["recurrence"].(string); ok {
+		if rec != "" {
+			if err := validateRRULE(rec); err != nil {
+				return "", err
+			}
+		}
 		updates["recurrence"] = rec
 	}
 
@@ -510,21 +525,25 @@ func (t *CalendarTool) updateThisAndFuture(ctx context.Context, ts oauth2.TokenS
 	}
 	if startStr, ok := input["start"].(string); ok && startStr != "" {
 		parsed, err := parseFlexibleTime(startStr, cal.Timezone)
-		if err == nil {
-			newStart = parsed
+		if err != nil {
+			return "", fmt.Errorf("invalid start time: %w", err)
 		}
+		newStart = parsed
 	}
 	if endStr, ok := input["end"].(string); ok && endStr != "" {
 		parsed, err := parseFlexibleTime(endStr, cal.Timezone)
-		if err == nil {
-			newEnd = parsed
+		if err != nil {
+			return "", fmt.Errorf("invalid end time: %w", err)
 		}
+		newEnd = parsed
 	}
 	if rec, ok := input["recurrence"].(string); ok && rec != "" {
+		if err := validateRRULE(rec); err != nil {
+			return "", err
+		}
 		newRecurrence = []string{rec}
 	}
 
-	// Remove any UNTIL/COUNT from new recurrence to let it continue
 	allDay := instance.Start != nil && instance.Start.Date != ""
 
 	created, err := CreateEvent(ctx, ts, cal.CalendarID, title, description, location, newStart, newEnd, allDay, cal.Timezone, newRecurrence)
@@ -543,9 +562,12 @@ func (t *CalendarTool) updateThisAndFuture(ctx context.Context, ts oauth2.TokenS
 }
 
 func (t *CalendarTool) execDelete(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
-	eventID, err := t.resolveEventID(ctx, ts, cal, input)
+	eventID, msg, err := t.resolveEventID(ctx, ts, cal, input)
 	if err != nil {
 		return "", err
+	}
+	if msg != "" {
+		return msg, nil
 	}
 	if eventID == "" {
 		return "", fmt.Errorf("event_id or title is required for delete")
@@ -631,24 +653,25 @@ func (t *CalendarTool) deleteThisAndFuture(ctx context.Context, ts oauth2.TokenS
 }
 
 // resolveEventID resolves an event ID from input, either directly or by title search.
-// Returns the event ID and a user-facing message if multiple matches are found.
-func (t *CalendarTool) resolveEventID(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, error) {
+// Returns (eventID, "", nil) on success, ("", message, nil) for user-facing guidance,
+// or ("", "", error) on actual errors.
+func (t *CalendarTool) resolveEventID(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, input map[string]any) (string, string, error) {
 	eventID, _ := input["event_id"].(string)
 	if eventID != "" {
-		return eventID, nil
+		return eventID, "", nil
 	}
 
 	title, _ := input["title"].(string)
 	if title == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	matches, err := FindEventByTitle(ctx, ts, cal.CalendarID, title)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if len(matches) == 0 {
-		return "", fmt.Errorf("no event found matching '%s'", title)
+		return "", fmt.Sprintf("No event found matching '%s'.", title), nil
 	}
 	if len(matches) > 1 {
 		var sb strings.Builder
@@ -656,9 +679,9 @@ func (t *CalendarTool) resolveEventID(ctx context.Context, ts oauth2.TokenSource
 		for _, m := range matches {
 			sb.WriteString(fmt.Sprintf("- %s (%s) [ID: %s]\n", m.Title, formatEventTime(m.Start), m.ID))
 		}
-		return "", fmt.Errorf("%s", sb.String())
+		return "", sb.String(), nil
 	}
-	return matches[0].ID, nil
+	return matches[0].ID, "", nil
 }
 
 func extractScope(input map[string]any) string {

--- a/tools/calendar/calendar.go
+++ b/tools/calendar/calendar.go
@@ -376,6 +376,19 @@ func (t *CalendarTool) execUpdate(ctx context.Context, ts oauth2.TokenSource, ca
 }
 
 func (t *CalendarTool) updateSingleInstance(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string, input map[string]any) (string, error) {
+	// Guard: if the event ID is a recurring master, updating it would affect all
+	// instances. Fetch the event to check.
+	raw, err := GetRawEvent(ctx, ts, cal.CalendarID, eventID)
+	if err != nil {
+		return "", err
+	}
+	if len(raw.Recurrence) > 0 {
+		return "This is a recurring event series. To update a single occurrence, first list events " +
+			"to get the specific instance ID, then update that instance. " +
+			"To update all occurrences, use scope='all'. " +
+			"To update this and all future occurrences, use scope='this_and_future'.", nil
+	}
+
 	updates := buildUpdates(input)
 
 	event, err := UpdateEvent(ctx, ts, cal.CalendarID, eventID, updates, cal.Timezone)
@@ -551,6 +564,19 @@ func (t *CalendarTool) execDelete(ctx context.Context, ts oauth2.TokenSource, ca
 }
 
 func (t *CalendarTool) deleteSingleInstance(ctx context.Context, ts oauth2.TokenSource, cal *TopicCalendar, eventID string) (string, error) {
+	// Guard: if the event ID is a recurring master, deleting it would remove the
+	// entire series. Fetch the event to check.
+	raw, err := GetRawEvent(ctx, ts, cal.CalendarID, eventID)
+	if err != nil {
+		return "", err
+	}
+	if len(raw.Recurrence) > 0 {
+		return "This is a recurring event series. To delete a single occurrence, first list events " +
+			"to get the specific instance ID, then delete that instance. " +
+			"To delete all occurrences, use scope='all'. " +
+			"To delete this and all future occurrences, use scope='this_and_future'.", nil
+	}
+
 	if err := DeleteEvent(ctx, ts, cal.CalendarID, eventID); err != nil {
 		return "", err
 	}

--- a/tools/calendar/client.go
+++ b/tools/calendar/client.go
@@ -24,14 +24,17 @@ type CalendarInfo struct {
 
 // EventInfo represents a Google Calendar event.
 type EventInfo struct {
-	ID          string
-	Title       string
-	Description string
-	Location    string
-	Start       string
-	End         string
-	AllDay      bool
-	HTMLLink    string
+	ID               string
+	Title            string
+	Description      string
+	Location         string
+	Start            string
+	End              string
+	AllDay           bool
+	HTMLLink         string
+	IsRecurring      bool
+	RecurringEventID string   // master event ID (populated on instances)
+	Recurrence       []string // RRULE strings (populated on master events)
 }
 
 // ListCalendars fetches the user's calendar list.
@@ -90,7 +93,7 @@ func ListEvents(ctx context.Context, ts oauth2.TokenSource, calendarID string, t
 }
 
 // CreateEvent creates a new event in the calendar.
-func CreateEvent(ctx context.Context, ts oauth2.TokenSource, calendarID string, title, description, location string, start, end time.Time, allDay bool, timezone string) (*EventInfo, error) {
+func CreateEvent(ctx context.Context, ts oauth2.TokenSource, calendarID string, title, description, location string, start, end time.Time, allDay bool, timezone string, recurrence []string) (*EventInfo, error) {
 	srv, err := gcalendar.NewService(ctx, option.WithTokenSource(ts))
 	if err != nil {
 		return nil, fmt.Errorf("creating calendar service: %w", err)
@@ -100,6 +103,10 @@ func CreateEvent(ctx context.Context, ts oauth2.TokenSource, calendarID string, 
 		Summary:     title,
 		Description: description,
 		Location:    location,
+	}
+
+	if len(recurrence) > 0 {
+		event.Recurrence = recurrence
 	}
 
 	if allDay {
@@ -186,7 +193,50 @@ func DeleteEvent(ctx context.Context, ts oauth2.TokenSource, calendarID, eventID
 	return nil
 }
 
+// GetRawEvent fetches a raw Google Calendar event by ID.
+func GetRawEvent(ctx context.Context, ts oauth2.TokenSource, calendarID, eventID string) (*gcalendar.Event, error) {
+	srv, err := gcalendar.NewService(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, fmt.Errorf("creating calendar service: %w", err)
+	}
+
+	event, err := srv.Events.Get(calendarID, eventID).Do()
+	if err != nil {
+		return nil, mapAPIError(err)
+	}
+	return event, nil
+}
+
+// UpdateRawEvent updates a raw Google Calendar event.
+func UpdateRawEvent(ctx context.Context, ts oauth2.TokenSource, calendarID, eventID string, event *gcalendar.Event) (*gcalendar.Event, error) {
+	srv, err := gcalendar.NewService(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, fmt.Errorf("creating calendar service: %w", err)
+	}
+
+	updated, err := srv.Events.Update(calendarID, eventID, event).SendUpdates("none").Do()
+	if err != nil {
+		return nil, mapAPIError(err)
+	}
+	return updated, nil
+}
+
+// masterEventID derives the master event ID from an instance ID.
+// Instance IDs have the format "{masterId}_{YYYYMMDDTHHMMSSZ}" or "{masterId}_{YYYYMMDD}".
+func masterEventID(eventID string) string {
+	if idx := strings.LastIndex(eventID, "_"); idx > 0 {
+		suffix := eventID[idx+1:]
+		// Check if suffix looks like a timestamp (8+ digits starting with a digit)
+		if len(suffix) >= 8 && suffix[0] >= '0' && suffix[0] <= '9' {
+			return eventID[:idx]
+		}
+	}
+	return eventID
+}
+
 // FindEventByTitle searches for events matching a title (case-insensitive).
+// Recurring event instances sharing the same master are deduplicated, returning
+// only the first instance.
 func FindEventByTitle(ctx context.Context, ts oauth2.TokenSource, calendarID, title string) ([]EventInfo, error) {
 	srv, err := gcalendar.NewService(ctx, option.WithTokenSource(ts))
 	if err != nil {
@@ -209,10 +259,19 @@ func FindEventByTitle(ctx context.Context, ts oauth2.TokenSource, calendarID, ti
 	}
 
 	var result []EventInfo
+	seen := make(map[string]bool) // track recurring master IDs to deduplicate
 	for _, item := range events.Items {
-		if strings.Contains(strings.ToLower(item.Summary), strings.ToLower(title)) {
-			result = append(result, eventToInfo(item))
+		if !strings.Contains(strings.ToLower(item.Summary), strings.ToLower(title)) {
+			continue
 		}
+		// Deduplicate recurring event instances: keep only the first occurrence
+		if item.RecurringEventId != "" {
+			if seen[item.RecurringEventId] {
+				continue
+			}
+			seen[item.RecurringEventId] = true
+		}
+		result = append(result, eventToInfo(item))
 	}
 	return result, nil
 }
@@ -240,6 +299,16 @@ func eventToInfo(e *gcalendar.Event) EventInfo {
 		} else {
 			info.End = e.End.DateTime
 		}
+	}
+
+	// Recurrence metadata
+	if len(e.Recurrence) > 0 {
+		info.IsRecurring = true
+		info.Recurrence = e.Recurrence
+	}
+	if e.RecurringEventId != "" {
+		info.IsRecurring = true
+		info.RecurringEventID = e.RecurringEventId
 	}
 
 	return info
@@ -284,6 +353,8 @@ func mapAPIError(err error) error {
 	}
 
 	switch apiErr.Code {
+	case 400:
+		return fmt.Errorf("Invalid request. If creating a recurring event, check the recurrence rule format (e.g., RRULE:FREQ=WEEKLY;BYDAY=TU).")
 	case 401:
 		return fmt.Errorf("Google Calendar access expired or was revoked. The topic owner needs to reconnect from settings.")
 	case 404:

--- a/tools/calendar/client.go
+++ b/tools/calendar/client.go
@@ -32,9 +32,7 @@ type EventInfo struct {
 	End              string
 	AllDay           bool
 	HTMLLink         string
-	IsRecurring      bool
-	RecurringEventID string   // master event ID (populated on instances)
-	Recurrence       []string // RRULE strings (populated on master events)
+	IsRecurring bool
 }
 
 // ListCalendars fetches the user's calendar list.
@@ -302,13 +300,8 @@ func eventToInfo(e *gcalendar.Event) EventInfo {
 	}
 
 	// Recurrence metadata
-	if len(e.Recurrence) > 0 {
+	if len(e.Recurrence) > 0 || e.RecurringEventId != "" {
 		info.IsRecurring = true
-		info.Recurrence = e.Recurrence
-	}
-	if e.RecurringEventId != "" {
-		info.IsRecurring = true
-		info.RecurringEventID = e.RecurringEventId
 	}
 
 	return info


### PR DESCRIPTION
## Summary
- Add `recurrence` parameter to create command accepting iCal RRULE strings (e.g., `RRULE:FREQ=WEEKLY;BYDAY=TU`)
- Add `scope` parameter to update/delete for recurring events: `single`, `all`, `this_and_future`
- Tool handles master-vs-instance ID resolution internally via `masterEventID` helper
- This-and-future operations use two-step approach (trim master + create new series) with rollback on failure
- List output shows `(recurring)` marker for recurring event instances
- Basic RRULE validation (prefix + FREQ check), Google API handles detailed validation
- `FindEventByTitle` deduplicates recurring instances sharing the same master
- Added 400 error mapping for user-friendly recurrence error messages

## Changes
| File | Changes |
|------|---------| 
| `tools/calendar/client.go` | `EventInfo` struct (`IsRecurring` field), `eventToInfo` recurrence extraction, `CreateEvent` recurrence param, `GetRawEvent`, `UpdateRawEvent`, `masterEventID` helper, `mapAPIError` 400 case, `FindEventByTitle` dedup |
| `tools/calendar/calendar.go` | `Schema()` (recurrence + scope), `Description()`, `ParseArgs` (flags incl. location), `execCreate` (recurrence), `execUpdate` (scope routing + 3 handlers), `execDelete` (scope routing + 3 handlers), `execList` (marker), `validateRRULE`, helper functions |

## Code review fixes (P2)
- Fixed schema `recurrence` description to mention update support (was "create only")
- Added `--location=` flag to ParseArgs for create and update slash commands
- Added `validateRRULE` calls to `updateAllInstances` and `updateThisAndFuture`
- Propagated time parse errors in `updateThisAndFuture` (was silently swallowed)
- Removed orphaned comment about UNTIL/COUNT removal
- Removed dead `EventInfo` fields (`RecurringEventID`, `Recurrence`) — YAGNI
- Fixed `resolveEventID` to return user-facing messages via `(string, nil)` instead of `fmt.Errorf`

## Test plan
- [x] Project builds successfully (`go build ./...`)
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` passes
- [ ] Manual: Create a recurring event via LLM ("create a weekly standup every Tuesday at 9am")
- [ ] Manual: List events and verify `(recurring)` marker appears
- [ ] Manual: Update single instance of recurring event
- [ ] Manual: Update all instances with `scope=all`
- [ ] Manual: Delete single instance of recurring event
- [x] Manual: Delete all instances with `scope=all`
- [ ] Manual: Slash command `/calendar create meeting 2026-03-10T09:00 2026-03-10T10:00 --recurrence=RRULE:FREQ=WEEKLY;BYDAY=TU`
- [x] Manual: Verified scope=single guard prevents accidental series deletion

## Post-Deploy Monitoring & Validation
- **What to monitor**: Calendar tool execution errors in application logs
- **Validation checks**: Create a recurring event, list to verify expansion, update/delete with different scopes
- **Expected healthy behavior**: Recurring events created as single Google Calendar series, scope operations route correctly
- **Failure signals**: 400 errors from Google API on RRULE creation, partial state on this-and-future operations
- **Validation window**: First 24 hours after deploy
- **Rollback trigger**: Persistent 400/500 errors on calendar operations that worked before

Closes #52

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)